### PR TITLE
Only Refresh SOAP Client Auth if Actually Needed

### DIFF
--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -100,7 +100,7 @@ module FuelSDK
     end
 
     def check_soap_client_for_refresh(window = 480)
-      if auth_token_expiration.nil? || Time.new + window > self.auth_token_expiration
+      if auth_token_expiration.nil? || Time.new + window > auth_token_expiration
         self.refresh!
         new_savon_client
       end
@@ -108,7 +108,7 @@ module FuelSDK
 
     def soap_client
       check_soap_client_for_refresh(300)
-      @soap_client || new_savon_client
+      @soap_client
     end
 
     def new_savon_client

--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -99,20 +99,16 @@ module FuelSDK
       @wsdl ||= 'https://webservice.exacttarget.com/etframework.wsdl'
     end
 
-    def check_soap_client_for_refresh
-      if auth_token_expiration.nil? || Time.new + 480 > self.auth_token_expiration
+    def check_soap_client_for_refresh(window = 480)
+      if auth_token_expiration.nil? || Time.new + window > self.auth_token_expiration
         self.refresh!
         new_savon_client
       end
     end
 
     def soap_client
-      if auth_token_expiration.nil? || Time.new + 300 > self.auth_token_expiration
-        self.refresh!
-        new_savon_client
-      else
-        @soap_client || new_savon_client
-      end
+      check_soap_client_for_refresh(300)
+      @soap_client || new_savon_client
     end
 
     def new_savon_client

--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -103,9 +103,6 @@ module FuelSDK
       if auth_token_expiration.nil? || Time.new + 480 > self.auth_token_expiration
         self.refresh!
         new_savon_client
-        true
-      else
-        false
       end
     end
 

--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -79,7 +79,7 @@ module FuelSDK
   end
 
   module Soap
-    attr_accessor :wsdl, :debug, :check_soap_client_for_refresh #, :internal_token
+    attr_accessor :wsdl, :debug #, :internal_token
 
     include FuelSDK::Targeting
 


### PR DESCRIPTION
Previously, whenever `soap_client` was called, it would refresh the client. Now, the client will only refresh and instantiate a new Savon client if we're 5 minutes away from the auth token expiring. This will save time when we're issuing many back-to-back requests to the Fuel API as we won't have to issue a GET request to refresh the client before every single POST SOAP request we fire off, which was the previous behavior.

This PR also adds and exposes another method for SOAP, `#check_soap_client_for_refresh`, which will refresh the client if its auth token is less than 8 minutes away from expiring. This is to accommodate a forthcoming change on the backend in `ExactTargetUnsubImporter`.
