### PR TITLE
Bump TLS from 1.0 to 1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fuelsdk (0.0.6)
+    fuelsdk (0.0.7)
       json (~> 1.7)
       jwt (~> 1.5.0)
       savon (~> 2.2)

--- a/fuelsdk.gemspec
+++ b/fuelsdk.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "fuelsdk"
-  s.version = "0.0.6"
+  s.version = "0.0.7"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["MichaelAllenClark", "barberj"]

--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -124,8 +124,8 @@ module FuelSDK
         logger Logger.new('/dev/null')
         open_timeout 100_000
         read_timeout 100_000
+        ssl_version :TLSv1_2
         # https://github.com/salesforce-marketingcloud/FuelSDK-Node-SOAP/issues/66
-        ssl_version :TLSv1
         # if Rails.env =~ /^prod/
         #   ssl_ca_cert_file '/etc/ssl/certs/ca-certificates.crt'
         # else

--- a/lib/new.rb
+++ b/lib/new.rb
@@ -168,7 +168,7 @@ module FuelSDK
             open_timeout 180
             read_timeout 180
             # https://github.com/salesforce-marketingcloud/FuelSDK-Node-SOAP/issues/66
-            ssl_version :TLSv1
+            ssl_version :TLSv1_2
             # if Rails.env =~ /^prod/
             #   ssl_ca_cert_file '/etc/ssl/certs/ca-certificates.crt'
             # else
@@ -239,8 +239,8 @@ module FuelSDK
             logger Logger.new('/dev/null')
             wsse_auth ["*", "*"]
             raise_errors false
+            ssl_version :TLSv1_2
             # https://github.com/salesforce-marketingcloud/FuelSDK-Node-SOAP/issues/66
-            ssl_version :TLSv1
             # if Rails.env =~ /^prod/
             #   ssl_ca_cert_file '/etc/ssl/certs/ca-certificates.crt'
             # else


### PR DESCRIPTION
Salesforce is disabling TLS 1.0 support on the SOAP API in January: https://help.salesforce.com/articleView?id=000270626&type=1